### PR TITLE
SQLite driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /npm-debug.log
 *~
+*.idea

--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ const orderBuilder = require('./lib/order-builder.js');
 const DRIVERS = {
 	'mysql': require('./lib/driver/mysql-driver.js'),
 	'pg': require('./lib/driver/pg-driver.js'),
-    'sqlite': require('./lib/driver/sqlite-driver.js')
+    'sqlite': require('./lib/driver/sqlite-driver.js'),
+    'sqlite3': require('./lib/driver/sqlite-driver.js')
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ const orderBuilder = require('./lib/order-builder.js');
  */
 const DRIVERS = {
 	'mysql': require('./lib/driver/mysql-driver.js'),
-	'pg': require('./lib/driver/pg-driver.js')
+	'pg': require('./lib/driver/pg-driver.js'),
+    'sqlite': require('./lib/driver/sqlite-driver.js')
 };
 
 /**

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -192,7 +192,9 @@ class SQLiteDriver extends BasicDBDriver {
     connect(source, handler) {
         if ((typeof source.acquire) === 'function') {
             source.acquire().then((connection) => {
-                handler.onSuccess(connection);
+                connection.run("PRAGMA foreign_keys = ON", [], err => {
+                    handler.onSuccess(connection);
+                });
             });
         } else {
             // TODO: figure out without a pool

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -185,10 +185,12 @@ class SQLiteDriver extends BasicDBDriver {
 
     connect(source, handler) {
         if ((typeof source.acquire) === 'function') {
-            source.acquire((connection) => {
+            source.acquire().then((connection) => {
+                console.log("Connect: Check 3");
                 handler.onSuccess(connection);
             });
         } else {
+            console.log("Erroring here...");
             // TODO: figure out without a pool
             handler.onError("not supported");
             //source.connect(err => {
@@ -211,7 +213,7 @@ class SQLiteDriver extends BasicDBDriver {
 
     startTransaction(connection, handler) {
 
-        connection.query('BEGIN TRANSACTION', [], err => {
+        connection.run('BEGIN TRANSACTION', [], err => {
             if (err)
                 handler.onError(err);
             else
@@ -221,7 +223,7 @@ class SQLiteDriver extends BasicDBDriver {
 
     rollbackTransaction(connection, handler) {
 
-        connection.query('ROLLBACK', [], err => {
+        connection.run('ROLLBACK', [], err => {
             if (err)
                 handler.onError(err);
             else
@@ -231,7 +233,7 @@ class SQLiteDriver extends BasicDBDriver {
 
     commitTransaction(connection, handler) {
 
-        connection.query('COMMIT', [], err => {
+        connection.run('COMMIT', [], err => {
             if (err)
                 handler.onError(err);
             else
@@ -358,46 +360,82 @@ class SQLiteDriver extends BasicDBDriver {
     }
 
     executeQuery(connection, statement, handler) {
-
-        const query = connection.query(statement);
-
-        query[HAS_ERROR] = false;
-
-        query.on('error', err => {
-            if (query[HAS_ERROR])
-                return;
-            query[HAS_ERROR] = true;
-            handler.onError(err);
+        //console.log(JSON.stringify(handler.onSuccess));
+        //const query =
+        connection.each(statement, [], function(err, row) {
+            if(err) {
+                handler.onError(err);
+            } else {
+                let keys = Object.keys(row);
+                handler.onHeader(keys);
+                //let convertedRow = {};
+                //keys.forEach(function(key) {
+                //    console.log(typeof row[key]);
+                //    if(typeof row[key] === "string") {
+                //        let dateResult = new Date(row[key]);
+                //        if(dateResult !== "Invalid Date" && !isNaN(dateResult)) {
+                //            convertedRow[key] = dateResult;
+                //        } else {
+                //            convertedRow[key] = row[key];
+                //        }
+                //    } else {
+                //        convertedRow[key] = row[key];
+                //    }
+                //    //arr[]
+                //    //try {
+                //    //    arr[key] = new Date(row[key]);
+                //    //}catch(e) {
+                //    //    arr[key] = row[key];
+                //    //}
+                //});
+                //console.log(convertedRow);
+                //handler.onRow(convertedRow);
+                handler.onRow(row);
+            }
+        }, function(a) {
+            console.log(a);
+            handler.onSuccess();
         });
 
-        query.on('end', () => {
-            if (!query[HAS_ERROR])
-                handler.onSuccess();
-        });
-
-        if (handler.onHeader)
-            query.on('fields', fields => {
-                if (query[HAS_ERROR])
-                    return;
-                try {
-                    handler.onHeader(fields.map(field => field.name));
-                } catch (err) {
-                    query[HAS_ERROR] = true;
-                    handler.onError(err);
-                }
-            });
-
-        if (handler.onRow)
-            query.on('result', row => {
-                if (query[HAS_ERROR])
-                    return;
-                try {
-                    handler.onRow(row);
-                } catch (err) {
-                    query[HAS_ERROR] = true;
-                    handler.onError(err);
-                }
-            });
+        //query[HAS_ERROR] = false;
+        //
+        //query.on('error', err => {
+        //    if (query[HAS_ERROR])
+        //        return;
+        //    query[HAS_ERROR] = true;
+        //    handler.onError(err);
+        //});
+        //
+        //query.on('end', () => {
+        //    if (!query[HAS_ERROR])
+        //        handler.onSuccess();
+        //});
+        //
+        //if (handler.onHeader)
+        //    query.on('fields', fields => {
+        //        if (query[HAS_ERROR])
+        //            return;
+        //        try {
+        //            handler.onHeader(fields.map(field => field.name));
+        //        } catch (err) {
+        //            query[HAS_ERROR] = true;
+        //            handler.onError(err);
+        //        }
+        //    });
+        //
+        //if (handler.onRow) {
+        //
+        //    query.on('result', row => {
+        //        if (query[HAS_ERROR])
+        //            return;
+        //        try {
+        //            handler.onRow(row);
+        //        } catch (err) {
+        //            query[HAS_ERROR] = true;
+        //            handler.onError(err);
+        //        }
+        //    });
+        //}
     }
 
     executeUpdate(connection, statement, handler) {

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -55,6 +55,11 @@ class SQLiteDriver extends BasicDBDriver {
         return `CAST(${expr} AS CHAR)`;
     }
 
+    booleanLiteral(val) {
+
+        return (val ? 1 : 0);
+    }
+
     patternMatch(expr, pattern, invert, caseSensitive) {
 
         return expr +
@@ -105,13 +110,18 @@ class SQLiteDriver extends BasicDBDriver {
 
         const hasRefTables = (refTables && (refTables.length > 0));
         const hasFilter = filterExpr;
+        if(hasFilter) {
+            let modifiedFilterExp = " " + filterExpr;
+            let regex = new RegExp(" " + fromTableAlias + "\\.", "g");
+            modifiedFilterExp = modifiedFilterExp.replace(regex, " ");
+            filterExpr = modifiedFilterExp;
+        }
 
-        return 'DELETE ' + fromTableAlias +
-            ' FROM ' + fromTableName + ' ' + fromTableAlias +
+        return 'DELETE FROM ' + fromTableName +
             (
                 hasRefTables ?
                     ', ' + refTables.map(
-                        t => t.tableName + ' ' + t.tableAlias).join(', ') :
+                        t => t.tableName).join(', ') :
                     ''
             ) +
             (

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -110,29 +110,29 @@ class SQLiteDriver extends BasicDBDriver {
             ' FROM ' + fromTableName + ' ' + fromTableAlias +
             (
                 hasRefTables ?
-                    ', ' + refTables.map(
-                        t => t.tableName + ' ' + t.tableAlias).join(', ') :
+                ', ' + refTables.map(
+                    t => t.tableName + ' ' + t.tableAlias).join(', ') :
                     ''
             ) +
             (
                 hasRefTables || hasFilter ?
-                    ' WHERE ' + (
-                        (
-                            hasRefTables ?
-                                refTables.map(
-                                    t => t.joinCondition).join(' AND ') :
-                                ''
-                        ) + (
-                            hasFilter && hasRefTables ?
-                                ' AND ' + (
-                                    filterExprParen ?
-                                        '(' + filterExpr + ')' : filterExpr
-                                ) :
-                                ''
-                        ) + (
-                            hasFilter && !hasRefTables ? filterExpr : ''
-                        )
-                    ) :
+                ' WHERE ' + (
+                    (
+                        hasRefTables ?
+                            refTables.map(
+                                t => t.joinCondition).join(' AND ') :
+                            ''
+                    ) + (
+                        hasFilter && hasRefTables ?
+                        ' AND ' + (
+                            filterExprParen ?
+                            '(' + filterExpr + ')' : filterExpr
+                        ) :
+                            ''
+                    ) + (
+                        hasFilter && !hasRefTables ? filterExpr : ''
+                    )
+                ) :
                     ''
             );
     }
@@ -160,8 +160,8 @@ class SQLiteDriver extends BasicDBDriver {
         var ret = 'UPDATE ' + updateTableName  + //+ ' ' + updateTableAlias
             (
                 hasRefTables ?
-                    ', ' + refTables.map(
-                        t => t.tableName ).join(', ') : //+ ' ' + t.tableAlias
+                ', ' + refTables.map(
+                    t => t.tableName ).join(', ') : //+ ' ' + t.tableAlias
                     ''
             ) +
             ' SET ' + sets.map(
@@ -169,23 +169,23 @@ class SQLiteDriver extends BasicDBDriver {
                 .join(', ') +
             (
                 hasRefTables || hasFilter ?
-                    ' WHERE ' + (
-                        (
-                            hasRefTables ?
-                                refTables.map(
-                                    t => t.joinCondition).join(' AND ') :
-                                ''
-                        ) + (
-                            hasFilter && hasRefTables ?
-                                ' AND ' + (
-                                    filterExprParen ?
-                                        '(' + filterExpr + ')' : filterExpr
-                                ) :
-                                ''
-                        ) + (
-                            hasFilter && !hasRefTables ? filterExpr : ''
-                        )
-                    ) :
+                ' WHERE ' + (
+                    (
+                        hasRefTables ?
+                            refTables.map(
+                                t => t.joinCondition).join(' AND ') :
+                            ''
+                    ) + (
+                        hasFilter && hasRefTables ?
+                        ' AND ' + (
+                            filterExprParen ?
+                            '(' + filterExpr + ')' : filterExpr
+                        ) :
+                            ''
+                    ) + (
+                        hasFilter && !hasRefTables ? filterExpr : ''
+                    )
+                ) :
                     ''
             );
         //console.log(ret);
@@ -301,14 +301,14 @@ class SQLiteDriver extends BasicDBDriver {
         const statusVarName = `@x2node.q.${topTableName}`;
         let sql;
         trace(sql = `SELECT ${statusVarName}`);
-        connection.query(sql, (err, result) => {
+        connection.get(sql, [], (err, result) => {
 
             if (err)
                 return handler.onError(err);
 
             if (result[0][statusVarName]) {
                 trace(sql = `TRUNCATE TABLE ${anchorTableName}`);
-                connection.query(sql, err => {
+                connection.run(sql, [], err => {
 
                     if (err)
                         return handler.onError(err);
@@ -326,13 +326,13 @@ class SQLiteDriver extends BasicDBDriver {
                         ` AS SELECT ${idColumnName} AS id, 0 AS ord` +
                         ` FROM ${topTableName} WHERE ${idColumnName} IS NULL`
                 );
-                connection.query(sql, err => {
+                connection.run(sql, err => {
 
                     if (err)
                         return handler.onError(err);
 
                     trace(sql = `SET ${statusVarName} = TRUE`);
-                    connection.query(sql, err => {
+                    connection.run(sql, err => {
 
                         if (err)
                             return handler.onError(err);
@@ -351,7 +351,7 @@ class SQLiteDriver extends BasicDBDriver {
 
         let sql;
         trace(sql = 'SET @x2node.ord = 0');
-        connection.query(sql, err => {
+        connection.run(sql, err => {
 
             if (err)
                 return handler.onError(err);
@@ -364,12 +364,12 @@ class SQLiteDriver extends BasicDBDriver {
                         '(@x2node.ord := @x2node.ord + 1) AS ord FROM'
                     )
             );
-            connection.query(sql, (err, result) => {
+            connection.run(sql, (err, result) => {
 
                 if (err)
                     return handler.onError(err);
 
-                handler.onSuccess(result.affectedRows);
+                handler.onSuccess(this.changes);
             });
         });
     }
@@ -412,7 +412,7 @@ class SQLiteDriver extends BasicDBDriver {
                 handler.onRow(row);
             }
         }, function(a) {
-            console.log(a);
+            //console.log(a);
             handler.onSuccess();
         });
 
@@ -507,9 +507,9 @@ class SQLiteDriver extends BasicDBDriver {
 
         const filterExpr = 'name' + (
                 itemNames.length === 1 ?
-                    ' = ' + this.stringLiteral(itemNames[0]) :
-                    ' IN (' + itemNames.map(v => this.stringLiteral(v)).join(', ') +
-                    ')'
+                ' = ' + this.stringLiteral(itemNames[0]) :
+                ' IN (' + itemNames.map(v => this.stringLiteral(v)).join(', ') +
+                ')'
             );
 
         const trace = (handler.trace || function() {});

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -110,29 +110,29 @@ class SQLiteDriver extends BasicDBDriver {
             ' FROM ' + fromTableName + ' ' + fromTableAlias +
             (
                 hasRefTables ?
-                ', ' + refTables.map(
-                    t => t.tableName + ' ' + t.tableAlias).join(', ') :
+                    ', ' + refTables.map(
+                        t => t.tableName + ' ' + t.tableAlias).join(', ') :
                     ''
             ) +
             (
                 hasRefTables || hasFilter ?
-                ' WHERE ' + (
-                    (
-                        hasRefTables ?
-                            refTables.map(
-                                t => t.joinCondition).join(' AND ') :
-                            ''
-                    ) + (
-                        hasFilter && hasRefTables ?
-                        ' AND ' + (
-                            filterExprParen ?
-                            '(' + filterExpr + ')' : filterExpr
-                        ) :
-                            ''
-                    ) + (
-                        hasFilter && !hasRefTables ? filterExpr : ''
-                    )
-                ) :
+                    ' WHERE ' + (
+                        (
+                            hasRefTables ?
+                                refTables.map(
+                                    t => t.joinCondition).join(' AND ') :
+                                ''
+                        ) + (
+                            hasFilter && hasRefTables ?
+                                ' AND ' + (
+                                    filterExprParen ?
+                                        '(' + filterExpr + ')' : filterExpr
+                                ) :
+                                ''
+                        ) + (
+                            hasFilter && !hasRefTables ? filterExpr : ''
+                        )
+                    ) :
                     ''
             );
     }
@@ -149,19 +149,11 @@ class SQLiteDriver extends BasicDBDriver {
             modifiedFilterExp = modifiedFilterExp.replace(regex, " ");
             filterExpr = modifiedFilterExp;
         }
-        //var temp = sets.map(
-        //    s => s.columnName + ' = ' + s.value) //updateTableName + '.'   updateTableAlias
-        //    .join(', ');
-        //console.log(temp);
-        //console.log("Sets:");
-        //console.log(sets);
-        //console.log("HasRefTables: "+hasRefTables);
-        //console.log("HasFilter: "+hasFilter);
         var ret = 'UPDATE ' + updateTableName  + //+ ' ' + updateTableAlias
             (
                 hasRefTables ?
-                ', ' + refTables.map(
-                    t => t.tableName ).join(', ') : //+ ' ' + t.tableAlias
+                    ', ' + refTables.map(
+                        t => t.tableName ).join(', ') : //+ ' ' + t.tableAlias
                     ''
             ) +
             ' SET ' + sets.map(
@@ -169,26 +161,25 @@ class SQLiteDriver extends BasicDBDriver {
                 .join(', ') +
             (
                 hasRefTables || hasFilter ?
-                ' WHERE ' + (
-                    (
-                        hasRefTables ?
-                            refTables.map(
-                                t => t.joinCondition).join(' AND ') :
-                            ''
-                    ) + (
-                        hasFilter && hasRefTables ?
-                        ' AND ' + (
-                            filterExprParen ?
-                            '(' + filterExpr + ')' : filterExpr
-                        ) :
-                            ''
-                    ) + (
-                        hasFilter && !hasRefTables ? filterExpr : ''
-                    )
-                ) :
+                    ' WHERE ' + (
+                        (
+                            hasRefTables ?
+                                refTables.map(
+                                    t => t.joinCondition).join(' AND ') :
+                                ''
+                        ) + (
+                            hasFilter && hasRefTables ?
+                                ' AND ' + (
+                                    filterExprParen ?
+                                        '(' + filterExpr + ')' : filterExpr
+                                ) :
+                                ''
+                        ) + (
+                            hasFilter && !hasRefTables ? filterExpr : ''
+                        )
+                    ) :
                     ''
             );
-        //console.log(ret);
         return ret;
     }
 
@@ -201,19 +192,11 @@ class SQLiteDriver extends BasicDBDriver {
     connect(source, handler) {
         if ((typeof source.acquire) === 'function') {
             source.acquire().then((connection) => {
-                //console.log("Connect: Check 3");
                 handler.onSuccess(connection);
             });
         } else {
-            console.log("Erroring here...");
             // TODO: figure out without a pool
             handler.onError("not supported");
-            //source.connect(err => {
-            //    if (err)
-            //        handler.onError(err);
-            //    else
-            //        handler.onSuccess(source);
-            //});
         }
     }
 
@@ -292,55 +275,30 @@ class SQLiteDriver extends BasicDBDriver {
         });
     }
 
-    selectIntoAnchorTable(
-        connection, anchorTableName, topTableName, idColumnName, idExpr,
-        statementStump, handler) {
-
+    selectIntoAnchorTable(connection, anchorTableName, topTableName, idColumnName, idExpr, statementStump, handler) {
         const trace = (handler.trace || function() {});
 
-        const statusVarName = `@x2node.q.${topTableName}`;
+        statementStump = statementStump.replace(
+                        /\bSELECT\s+\{\*\}\s+FROM\b/i,
+                        `SELECT z.rowid AS rownumber, ${idExpr} AS id FROM`
+                    );
+        let statementStumpLockIndex = statementStump.indexOf("LOCK IN SHARE MODE");
+        if(statementStumpLockIndex > 0) {
+            statementStump = statementStump.substring(0, statementStumpLockIndex);
+        }
         let sql;
-        trace(sql = `SELECT ${statusVarName}`);
-        connection.get(sql, [], (err, result) => {
-
-            if (err)
+        trace(sql = `CREATE TEMPORARY TABLE IF NOT EXISTS ${anchorTableName} (id, ord)`);
+        connection.run(sql, [], (err, result) => {
+            if (err) {
                 return handler.onError(err);
-
-            if (result[0][statusVarName]) {
-                trace(sql = `TRUNCATE TABLE ${anchorTableName}`);
-                connection.run(sql, [], err => {
-
-                    if (err)
-                        return handler.onError(err);
-
-                    this._executeSelectIntoAnchorTable(
-                        connection, anchorTableName, idExpr, statementStump,
-                        handler, trace);
-                });
-
             } else {
-
-                trace(
-                    sql = `CREATE TEMPORARY TABLE ${anchorTableName}` +
-                        ' (UNIQUE(id), ord INTEGER UNSIGNED NOT NULL UNIQUE)' +
-                        ` AS SELECT ${idColumnName} AS id, 0 AS ord` +
-                        ` FROM ${topTableName} WHERE ${idColumnName} IS NULL`
-                );
-                connection.run(sql, err => {
-
-                    if (err)
-                        return handler.onError(err);
-
-                    trace(sql = `SET ${statusVarName} = TRUE`);
-                    connection.run(sql, err => {
-
-                        if (err)
-                            return handler.onError(err);
-
-                        this._executeSelectIntoAnchorTable(
-                            connection, anchorTableName, idExpr, statementStump,
-                            handler, trace);
-                    });
+                trace(sql = `DELETE FROM ${anchorTableName}`);
+                connection.run(sql, [], (err2, result2) => {
+                    if (err2) {
+                        return handler.onError(err2);
+                    } else {
+                        this._executeSelectIntoAnchorTable(connection, anchorTableName, idExpr, statementStump, handler, trace);
+                    }
                 });
             }
         });
@@ -350,33 +308,33 @@ class SQLiteDriver extends BasicDBDriver {
         connection, anchorTableName, idExpr, statementStump, handler, trace) {
 
         let sql;
-        trace(sql = 'SET @x2node.ord = 0');
-        connection.run(sql, err => {
+        trace(sql = statementStump);
+        connection.all(sql, [], function(err, rows) {
 
-            if (err)
+            if (err) {
                 return handler.onError(err);
-
-            trace(
-                sql = `INSERT INTO ${anchorTableName} (id, ord) ` +
-                    statementStump.replace(
-                        /\bSELECT\s+\{\*\}\s+FROM\b/i,
-                        `SELECT ${idExpr} AS id, ` +
-                        '(@x2node.ord := @x2node.ord + 1) AS ord FROM'
-                    )
-            );
-            connection.run(sql, (err, result) => {
-
-                if (err)
-                    return handler.onError(err);
-
-                handler.onSuccess(this.changes);
-            });
+            } else {
+                let valueString = "";
+                rows.forEach(function(row) {
+                    valueString += "(" + row.id + ', ' + row.rownumber + "),";
+                });
+                if(valueString.trim() !== "") {
+                    valueString = valueString.substring(0, valueString.length - 1);
+                    trace(sql = 'INSERT INTO ' + anchorTableName + ' (id, ord) VALUES ' + valueString);
+                    connection.run(sql, (err, result) => {
+                        if (err) {
+                            return handler.onError(err);
+                        }
+                        handler.onSuccess([]);
+                    });
+                } else {
+                    handler.onSuccess([]);
+                }
+            }
         });
     }
 
     executeQuery(connection, statement, handler) {
-        //console.log(JSON.stringify(handler.onSuccess));
-        //const query =
         let headersSet = false;
         connection.each(statement, [], function(err, row) {
             if(err) {
@@ -387,79 +345,14 @@ class SQLiteDriver extends BasicDBDriver {
                     handler.onHeader(keys);
                     headersSet = true;
                 }
-                //let convertedRow = {};
-                //keys.forEach(function(key) {
-                //    console.log(typeof row[key]);
-                //    if(typeof row[key] === "string") {
-                //        let dateResult = new Date(row[key]);
-                //        if(dateResult !== "Invalid Date" && !isNaN(dateResult)) {
-                //            convertedRow[key] = dateResult;
-                //        } else {
-                //            convertedRow[key] = row[key];
-                //        }
-                //    } else {
-                //        convertedRow[key] = row[key];
-                //    }
-                //    //arr[]
-                //    //try {
-                //    //    arr[key] = new Date(row[key]);
-                //    //}catch(e) {
-                //    //    arr[key] = row[key];
-                //    //}
-                //});
-                //console.log(convertedRow);
-                //handler.onRow(convertedRow);
                 handler.onRow(row);
             }
         }, function(a) {
-            //console.log(a);
             handler.onSuccess();
         });
-
-        //query[HAS_ERROR] = false;
-        //
-        //query.on('error', err => {
-        //    if (query[HAS_ERROR])
-        //        return;
-        //    query[HAS_ERROR] = true;
-        //    handler.onError(err);
-        //});
-        //
-        //query.on('end', () => {
-        //    if (!query[HAS_ERROR])
-        //        handler.onSuccess();
-        //});
-        //
-        //if (handler.onHeader)
-        //    query.on('fields', fields => {
-        //        if (query[HAS_ERROR])
-        //            return;
-        //        try {
-        //            handler.onHeader(fields.map(field => field.name));
-        //        } catch (err) {
-        //            query[HAS_ERROR] = true;
-        //            handler.onError(err);
-        //        }
-        //    });
-        //
-        //if (handler.onRow) {
-        //
-        //    query.on('result', row => {
-        //        if (query[HAS_ERROR])
-        //            return;
-        //        try {
-        //            handler.onRow(row);
-        //        } catch (err) {
-        //            query[HAS_ERROR] = true;
-        //            handler.onError(err);
-        //        }
-        //    });
-        //}
     }
 
     executeUpdate(connection, statement, handler) {
-        console.log("Statement:");
-        console.log(statement);
         connection.run(statement, [], function(err, result) {
 
             if (err)
@@ -475,8 +368,6 @@ class SQLiteDriver extends BasicDBDriver {
             if (err) {
                 handler.onError(err);
             } else {
-                //console.log(this);
-                //result.insertId
                 handler.onSuccess(this.lastID);
             }
         });
@@ -507,9 +398,9 @@ class SQLiteDriver extends BasicDBDriver {
 
         const filterExpr = 'name' + (
                 itemNames.length === 1 ?
-                ' = ' + this.stringLiteral(itemNames[0]) :
-                ' IN (' + itemNames.map(v => this.stringLiteral(v)).join(', ') +
-                ')'
+                    ' = ' + this.stringLiteral(itemNames[0]) :
+                    ' IN (' + itemNames.map(v => this.stringLiteral(v)).join(', ') +
+                    ')'
             );
 
         const trace = (handler.trace || function() {});

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -1,0 +1,29 @@
+class SqliteDriver extends BasicDBDriver{
+
+    constructor(options) {
+        super(options);
+    }
+
+    supportsRowLocksWithAggregates() { return false; }
+
+    safeLikePatternFromExpr(expr) {
+        return `REPLACE(REPLACE(REPLACE(${expr}, '\\\\', '\\\\\\\\'),` +
+            ` '%', '\\%'), '_', '\\_')`;
+    }
+
+    stringSubstring(expr, from, len) {
+
+        return 'SUBSTRING(' + expr +
+            ', ' + (
+                (typeof from) === 'number' ?
+                    String(from + 1) : '(' + String(from) + ') + 1'
+            ) +
+            (len !== undefined ? ', ' + String(len) : '') + ')';
+    }
+
+    nullableConcat() {
+
+        return 'CONCAT(' + Array.from(arguments).join(', ') + ')';
+    }
+
+}

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -184,36 +184,34 @@ class SQLiteDriver extends BasicDBDriver {
     }
 
     connect(source, handler) {
-
-        if ((typeof source.getConnection) === 'function') {
-            source.getConnection((err, connection) => {
-                if (err)
-                    handler.onError(err);
-                else
-                    handler.onSuccess(connection);
+        if ((typeof source.acquire) === 'function') {
+            source.acquire((connection) => {
+                handler.onSuccess(connection);
             });
         } else {
-            source.connect(err => {
-                if (err)
-                    handler.onError(err);
-                else
-                    handler.onSuccess(source);
-            });
+            // TODO: figure out without a pool
+            handler.onError("not supported");
+            //source.connect(err => {
+            //    if (err)
+            //        handler.onError(err);
+            //    else
+            //        handler.onSuccess(source);
+            //});
         }
     }
 
     releaseConnection(source, connection) {
-
-        if ((typeof source.getConnection) === 'function') {
-            connection.release();
+        if ((typeof source.acquire) === 'function') {
+            source.release(connection);
         } else {
+            // TODO: figure out without a pool
             connection.end();
         }
     }
 
     startTransaction(connection, handler) {
 
-        connection.query('START TRANSACTION', err => {
+        connection.query('BEGIN TRANSACTION', [], err => {
             if (err)
                 handler.onError(err);
             else
@@ -223,7 +221,7 @@ class SQLiteDriver extends BasicDBDriver {
 
     rollbackTransaction(connection, handler) {
 
-        connection.query('ROLLBACK', err => {
+        connection.query('ROLLBACK', [], err => {
             if (err)
                 handler.onError(err);
             else
@@ -233,7 +231,7 @@ class SQLiteDriver extends BasicDBDriver {
 
     commitTransaction(connection, handler) {
 
-        connection.query('COMMIT', err => {
+        connection.query('COMMIT', [], err => {
             if (err)
                 handler.onError(err);
             else

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -86,7 +86,7 @@ class SQLiteDriver extends BasicDBDriver {
 
         return selectStmt + (
                 exclusiveLockTables && (exclusiveLockTables.length > 0) ?
-                    ' FOR UPDATE' : (
+                    '' : (
                     sharedLockTables && (sharedLockTables.length > 0) ?
                         ' LOCK IN SHARE MODE' : ''
                 )
@@ -107,11 +107,11 @@ class SQLiteDriver extends BasicDBDriver {
         const hasFilter = filterExpr;
 
         return 'DELETE ' + fromTableAlias +
-            ' FROM ' + fromTableName + ' AS ' + fromTableAlias +
+            ' FROM ' + fromTableName + ' ' + fromTableAlias +
             (
                 hasRefTables ?
                     ', ' + refTables.map(
-                        t => t.tableName + ' AS ' + t.tableAlias).join(', ') :
+                        t => t.tableName + ' ' + t.tableAlias).join(', ') :
                     ''
             ) +
             (
@@ -143,16 +143,29 @@ class SQLiteDriver extends BasicDBDriver {
 
         const hasRefTables = (refTables && (refTables.length > 0));
         const hasFilter = filterExpr;
-
-        return 'UPDATE ' + updateTableName + ' AS ' + updateTableAlias +
+        if(hasFilter) {
+            let modifiedFilterExp = " " + filterExpr;
+            let regex = new RegExp(" " + updateTableAlias + "\\.", "g");
+            modifiedFilterExp = modifiedFilterExp.replace(regex, " ");
+            filterExpr = modifiedFilterExp;
+        }
+        //var temp = sets.map(
+        //    s => s.columnName + ' = ' + s.value) //updateTableName + '.'   updateTableAlias
+        //    .join(', ');
+        //console.log(temp);
+        //console.log("Sets:");
+        //console.log(sets);
+        //console.log("HasRefTables: "+hasRefTables);
+        //console.log("HasFilter: "+hasFilter);
+        var ret = 'UPDATE ' + updateTableName  + //+ ' ' + updateTableAlias
             (
                 hasRefTables ?
                     ', ' + refTables.map(
-                        t => t.tableName + ' AS ' + t.tableAlias).join(', ') :
+                        t => t.tableName ).join(', ') : //+ ' ' + t.tableAlias
                     ''
             ) +
             ' SET ' + sets.map(
-                s => updateTableAlias + '.' + s.columnName + ' = ' + s.value)
+                s => s.columnName + ' = ' + s.value) // updateTableName + '.'  updateTableAlias
                 .join(', ') +
             (
                 hasRefTables || hasFilter ?
@@ -175,6 +188,8 @@ class SQLiteDriver extends BasicDBDriver {
                     ) :
                     ''
             );
+        //console.log(ret);
+        return ret;
     }
 
     buildUpsert(tableName, insertColumns, insertValues, uniqueColumn, sets) {
@@ -186,7 +201,7 @@ class SQLiteDriver extends BasicDBDriver {
     connect(source, handler) {
         if ((typeof source.acquire) === 'function') {
             source.acquire().then((connection) => {
-                console.log("Connect: Check 3");
+                //console.log("Connect: Check 3");
                 handler.onSuccess(connection);
             });
         } else {
@@ -362,12 +377,16 @@ class SQLiteDriver extends BasicDBDriver {
     executeQuery(connection, statement, handler) {
         //console.log(JSON.stringify(handler.onSuccess));
         //const query =
+        let headersSet = false;
         connection.each(statement, [], function(err, row) {
             if(err) {
                 handler.onError(err);
             } else {
                 let keys = Object.keys(row);
-                handler.onHeader(keys);
+                if(!headersSet) {
+                    handler.onHeader(keys);
+                    headersSet = true;
+                }
                 //let convertedRow = {};
                 //keys.forEach(function(key) {
                 //    console.log(typeof row[key]);
@@ -439,24 +458,27 @@ class SQLiteDriver extends BasicDBDriver {
     }
 
     executeUpdate(connection, statement, handler) {
-
-        connection.query(statement, (err, result) => {
+        console.log("Statement:");
+        console.log(statement);
+        connection.run(statement, [], function(err, result) {
 
             if (err)
                 handler.onError(err);
-            else
-                handler.onSuccess(result.affectedRows);
+            else {
+                handler.onSuccess(this.changes);
+            }
         });
     }
 
     executeInsert(connection, statement, handler) {
-
-        connection.query(statement, (err, result) => {
-
-            if (err)
+        connection.run(statement, [], function(err, result) {
+            if (err) {
                 handler.onError(err);
-            else
-                handler.onSuccess(result.insertId);
+            } else {
+                //console.log(this);
+                //result.insertId
+                handler.onSuccess(this.lastID);
+            }
         });
     }
 

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -488,4 +488,4 @@ class SQLiteDriver extends BasicDBDriver {
     }
 }
 
-module.exports = MySQLDBDriver;
+module.exports = SQLiteDriver;

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -10,20 +10,33 @@ const BasicDBDriver = require('./basic-driver.js');
  */
 const HAS_ERROR = Symbol();
 
-class SqliteDriver extends BasicDBDriver{
+/**
+ * SQLite database driver.
+ *
+ * @private
+ * @memberof module:x2node-dbos
+ * @inner
+ * @extends {module:x2node-dbos~BasicDBDriver}
+ * @implements {module:x2node-dbos.DBDriver}
+ */
+class SQLiteDriver extends BasicDBDriver {
 
     constructor(options) {
         super(options);
+
+        this._charset = ((options && options.databaseCharacterSet) || 'utf8');
     }
 
-    supportsRowLocksWithAggregates() { return false; }
+    supportsRowLocksWithAggregates() { return true; }
 
     safeLikePatternFromExpr(expr) {
+
         return `REPLACE(REPLACE(REPLACE(${expr}, '\\\\', '\\\\\\\\'),` +
             ` '%', '\\%'), '_', '\\_')`;
     }
 
     stringSubstring(expr, from, len) {
+
         return 'SUBSTRING(' + expr +
             ', ' + (
                 (typeof from) === 'number' ?
@@ -33,11 +46,448 @@ class SqliteDriver extends BasicDBDriver{
     }
 
     nullableConcat() {
+
         return 'CONCAT(' + Array.from(arguments).join(', ') + ')';
     }
 
-
     castToString(expr) {
+
         return `CAST(${expr} AS CHAR)`;
     }
+
+    patternMatch(expr, pattern, invert, caseSensitive) {
+
+        return expr +
+            ' COLLATE ' + this._charset +
+            (caseSensitive ? '_bin' : '_general_ci') +
+            (invert ? ' NOT' : '') + ' LIKE ' + pattern;
+    }
+
+    regexpMatch(expr, regexp, invert, caseSensitive) {
+
+        return expr +
+            ' COLLATE ' + this._charset +
+            (caseSensitive ? '_bin' : '_general_ci') +
+            (invert ? ' NOT' : '') + ' REGEXP ' + regexp;
+    }
+
+    /*datetimeToString(expr) {
+
+     return 'DATE_FORMAT(' + expr + ', \'%Y-%m%dT%TZ\')';
+     }*/
+
+    makeRangedSelect(selectStmt, offset, limit) {
+
+        return selectStmt + ' LIMIT ' +
+            (offset > 0 ? String(offset) + ', ' : '') + limit;
+    }
+
+    makeSelectWithLocks(selectStmt, exclusiveLockTables, sharedLockTables) {
+
+        return selectStmt + (
+                exclusiveLockTables && (exclusiveLockTables.length > 0) ?
+                    ' FOR UPDATE' : (
+                    sharedLockTables && (sharedLockTables.length > 0) ?
+                        ' LOCK IN SHARE MODE' : ''
+                )
+            );
+    }
+
+    buildLockTables() {
+
+        throw new Error(
+            'Internal X2 error: transaction scope table locks are' +
+            ' not supported by MySQL.');
+    }
+
+    buildDeleteWithJoins(
+        fromTableName, fromTableAlias, refTables, filterExpr, filterExprParen) {
+
+        const hasRefTables = (refTables && (refTables.length > 0));
+        const hasFilter = filterExpr;
+
+        return 'DELETE ' + fromTableAlias +
+            ' FROM ' + fromTableName + ' AS ' + fromTableAlias +
+            (
+                hasRefTables ?
+                    ', ' + refTables.map(
+                        t => t.tableName + ' AS ' + t.tableAlias).join(', ') :
+                    ''
+            ) +
+            (
+                hasRefTables || hasFilter ?
+                    ' WHERE ' + (
+                        (
+                            hasRefTables ?
+                                refTables.map(
+                                    t => t.joinCondition).join(' AND ') :
+                                ''
+                        ) + (
+                            hasFilter && hasRefTables ?
+                                ' AND ' + (
+                                    filterExprParen ?
+                                        '(' + filterExpr + ')' : filterExpr
+                                ) :
+                                ''
+                        ) + (
+                            hasFilter && !hasRefTables ? filterExpr : ''
+                        )
+                    ) :
+                    ''
+            );
+    }
+
+    buildUpdateWithJoins(
+        updateTableName, updateTableAlias, sets, refTables, filterExpr,
+        filterExprParen) {
+
+        const hasRefTables = (refTables && (refTables.length > 0));
+        const hasFilter = filterExpr;
+
+        return 'UPDATE ' + updateTableName + ' AS ' + updateTableAlias +
+            (
+                hasRefTables ?
+                    ', ' + refTables.map(
+                        t => t.tableName + ' AS ' + t.tableAlias).join(', ') :
+                    ''
+            ) +
+            ' SET ' + sets.map(
+                s => updateTableAlias + '.' + s.columnName + ' = ' + s.value)
+                .join(', ') +
+            (
+                hasRefTables || hasFilter ?
+                    ' WHERE ' + (
+                        (
+                            hasRefTables ?
+                                refTables.map(
+                                    t => t.joinCondition).join(' AND ') :
+                                ''
+                        ) + (
+                            hasFilter && hasRefTables ?
+                                ' AND ' + (
+                                    filterExprParen ?
+                                        '(' + filterExpr + ')' : filterExpr
+                                ) :
+                                ''
+                        ) + (
+                            hasFilter && !hasRefTables ? filterExpr : ''
+                        )
+                    ) :
+                    ''
+            );
+    }
+
+    buildUpsert(tableName, insertColumns, insertValues, uniqueColumn, sets) {
+
+        return `INSERT INTO ${tableName} (${insertColumns})` +
+            ` VALUES (${insertValues}) ON DUPLICATE KEY UPDATE ${sets}`;
+    }
+
+    connect(source, handler) {
+
+        if ((typeof source.getConnection) === 'function') {
+            source.getConnection((err, connection) => {
+                if (err)
+                    handler.onError(err);
+                else
+                    handler.onSuccess(connection);
+            });
+        } else {
+            source.connect(err => {
+                if (err)
+                    handler.onError(err);
+                else
+                    handler.onSuccess(source);
+            });
+        }
+    }
+
+    releaseConnection(source, connection) {
+
+        if ((typeof source.getConnection) === 'function') {
+            connection.release();
+        } else {
+            connection.end();
+        }
+    }
+
+    startTransaction(connection, handler) {
+
+        connection.query('START TRANSACTION', err => {
+            if (err)
+                handler.onError(err);
+            else
+                handler.onSuccess();
+        });
+    }
+
+    rollbackTransaction(connection, handler) {
+
+        connection.query('ROLLBACK', err => {
+            if (err)
+                handler.onError(err);
+            else
+                handler.onSuccess();
+        });
+    }
+
+    commitTransaction(connection, handler) {
+
+        connection.query('COMMIT', err => {
+            if (err)
+                handler.onError(err);
+            else
+                handler.onSuccess();
+        });
+    }
+
+    setSessionVariable(connection, varName, valueExpr, handler) {
+
+        connection.query(`SET @${varName} = ${valueExpr}`, err => {
+
+            if (err)
+                handler.onError(err);
+            else
+                handler.onSuccess();
+        });
+    }
+
+    getSessionVariable(connection, varName, type, handler) {
+
+        connection.query(`SELECT @${varName}`, (err, result) => {
+
+            if (err)
+                return handler.onError(err);
+
+            const valRaw = result[0]['@' + varName];
+
+            if (valRaw === null)
+                return handler.onSuccess();
+
+            switch (type) {
+                case 'number':
+                    handler.onSuccess(Number(valRaw));
+                    break;
+                case 'boolean':
+                    handler.onSuccess(valRaw ? true : false);
+                    break;
+                default:
+                    handler.onSuccess(valRaw);
+            }
+        });
+    }
+
+    selectIntoAnchorTable(
+        connection, anchorTableName, topTableName, idColumnName, idExpr,
+        statementStump, handler) {
+
+        const trace = (handler.trace || function() {});
+
+        const statusVarName = `@x2node.q.${topTableName}`;
+        let sql;
+        trace(sql = `SELECT ${statusVarName}`);
+        connection.query(sql, (err, result) => {
+
+            if (err)
+                return handler.onError(err);
+
+            if (result[0][statusVarName]) {
+                trace(sql = `TRUNCATE TABLE ${anchorTableName}`);
+                connection.query(sql, err => {
+
+                    if (err)
+                        return handler.onError(err);
+
+                    this._executeSelectIntoAnchorTable(
+                        connection, anchorTableName, idExpr, statementStump,
+                        handler, trace);
+                });
+
+            } else {
+
+                trace(
+                    sql = `CREATE TEMPORARY TABLE ${anchorTableName}` +
+                        ' (UNIQUE(id), ord INTEGER UNSIGNED NOT NULL UNIQUE)' +
+                        ` AS SELECT ${idColumnName} AS id, 0 AS ord` +
+                        ` FROM ${topTableName} WHERE ${idColumnName} IS NULL`
+                );
+                connection.query(sql, err => {
+
+                    if (err)
+                        return handler.onError(err);
+
+                    trace(sql = `SET ${statusVarName} = TRUE`);
+                    connection.query(sql, err => {
+
+                        if (err)
+                            return handler.onError(err);
+
+                        this._executeSelectIntoAnchorTable(
+                            connection, anchorTableName, idExpr, statementStump,
+                            handler, trace);
+                    });
+                });
+            }
+        });
+    }
+
+    _executeSelectIntoAnchorTable(
+        connection, anchorTableName, idExpr, statementStump, handler, trace) {
+
+        let sql;
+        trace(sql = 'SET @x2node.ord = 0');
+        connection.query(sql, err => {
+
+            if (err)
+                return handler.onError(err);
+
+            trace(
+                sql = `INSERT INTO ${anchorTableName} (id, ord) ` +
+                    statementStump.replace(
+                        /\bSELECT\s+\{\*\}\s+FROM\b/i,
+                        `SELECT ${idExpr} AS id, ` +
+                        '(@x2node.ord := @x2node.ord + 1) AS ord FROM'
+                    )
+            );
+            connection.query(sql, (err, result) => {
+
+                if (err)
+                    return handler.onError(err);
+
+                handler.onSuccess(result.affectedRows);
+            });
+        });
+    }
+
+    executeQuery(connection, statement, handler) {
+
+        const query = connection.query(statement);
+
+        query[HAS_ERROR] = false;
+
+        query.on('error', err => {
+            if (query[HAS_ERROR])
+                return;
+            query[HAS_ERROR] = true;
+            handler.onError(err);
+        });
+
+        query.on('end', () => {
+            if (!query[HAS_ERROR])
+                handler.onSuccess();
+        });
+
+        if (handler.onHeader)
+            query.on('fields', fields => {
+                if (query[HAS_ERROR])
+                    return;
+                try {
+                    handler.onHeader(fields.map(field => field.name));
+                } catch (err) {
+                    query[HAS_ERROR] = true;
+                    handler.onError(err);
+                }
+            });
+
+        if (handler.onRow)
+            query.on('result', row => {
+                if (query[HAS_ERROR])
+                    return;
+                try {
+                    handler.onRow(row);
+                } catch (err) {
+                    query[HAS_ERROR] = true;
+                    handler.onError(err);
+                }
+            });
+    }
+
+    executeUpdate(connection, statement, handler) {
+
+        connection.query(statement, (err, result) => {
+
+            if (err)
+                handler.onError(err);
+            else
+                handler.onSuccess(result.affectedRows);
+        });
+    }
+
+    executeInsert(connection, statement, handler) {
+
+        connection.query(statement, (err, result) => {
+
+            if (err)
+                handler.onError(err);
+            else
+                handler.onSuccess(result.insertId);
+        });
+    }
+
+    createVersionTableIfNotExists(connection, tableName, handler) {
+
+        const trace = (handler.trace || function() {});
+        let sql;
+        trace(
+            sql = `CREATE TABLE IF NOT EXISTS ${tableName} (` +
+                'name VARCHAR(64) PRIMARY KEY, ' +
+                'modified_on TIMESTAMP(3) DEFAULT 0, ' +
+                'version INTEGER UNSIGNED NOT NULL)'
+        );
+
+        connection.query(sql, err => {
+
+            if (err)
+                handler.onError(err);
+            else
+                handler.onSuccess();
+        });
+    }
+
+    updateVersionTable(
+        connection, tableName, itemNames, modificationTimestamp, handler) {
+
+        const filterExpr = 'name' + (
+                itemNames.length === 1 ?
+                    ' = ' + this.stringLiteral(itemNames[0]) :
+                    ' IN (' + itemNames.map(v => this.stringLiteral(v)).join(', ') +
+                    ')'
+            );
+
+        const trace = (handler.trace || function() {});
+        let sql;
+        trace(
+            sql = `UPDATE ${tableName} SET ` +
+                `modified_on = '${modificationTimestamp}', ` +
+                `version = version + 1 WHERE ${filterExpr}`
+        );
+        connection.query(sql, (err, result) => {
+
+            if (err)
+                return handler.onError(err);
+
+            if (result.affectedRows === itemNames.length)
+                return handler.onSuccess();
+
+            sql = `INSERT INTO ${tableName} (name, modified_on, version) VALUES`;
+            for (let i = 0, len = itemNames.length; i < len; i++) {
+                if (i > 0)
+                    sql += ',';
+                sql += ' (' + this.stringLiteral(itemNames[i]) +
+                    ', \'' + modificationTimestamp + '\', 1)';
+            }
+            sql += ' ON DUPLICATE KEY UPDATE modified_on = \'' +
+                modificationTimestamp + '\', version = version + 1';
+            trace(sql);
+            connection.query(sql, err => {
+
+                if (err)
+                    return handler.onError(err);
+
+                handler.onSuccess();
+            });
+        });
+    }
 }
+
+module.exports = MySQLDBDriver;

--- a/lib/driver/sqlite-driver.js
+++ b/lib/driver/sqlite-driver.js
@@ -1,3 +1,15 @@
+'use strict';
+
+const BasicDBDriver = require('./basic-driver.js');
+
+
+/**
+ * Symbol used to indicate that there is an error on the query object.
+ *
+ * @private
+ */
+const HAS_ERROR = Symbol();
+
 class SqliteDriver extends BasicDBDriver{
 
     constructor(options) {
@@ -12,7 +24,6 @@ class SqliteDriver extends BasicDBDriver{
     }
 
     stringSubstring(expr, from, len) {
-
         return 'SUBSTRING(' + expr +
             ', ' + (
                 (typeof from) === 'number' ?
@@ -22,8 +33,11 @@ class SqliteDriver extends BasicDBDriver{
     }
 
     nullableConcat() {
-
         return 'CONCAT(' + Array.from(arguments).join(', ') + ')';
     }
 
+
+    castToString(expr) {
+        return `CAST(${expr} AS CHAR)`;
+    }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": ">=4.3.2"
   },
   "dependencies": {
+    "generic-pool": "^3.1.7",
     "x2node-common": "^1.3.2",
     "x2node-patches": "^1.1.4",
     "x2node-pointers": "^1.2.3",


### PR DESCRIPTION
We added an alpha implementation of the SQLite Driver. The MySQL Driver was used as a base for the SQLite Driver. It was designed to support SQLite3. We have implemented the following functions:

1. buildUpdateWithJoins()
2. connect()
3. releaseConnection()
4. startTransaction()
5. rollbackTransaction()
6. commitTransaction()
7. selectIntoAnchorTable()
8. _executeSelectIntoAnchorTable()
9. executeQuery()
10. executeUpdate()
11. executeInsert()

All other functions have not been worked on, so they may not be functional at the moment. Additionally, we used the SQLite Driver on our side using the "generic-pool" library, so using the SQLite Driver without a pool has not been implemented.